### PR TITLE
Restore map and menu music on state transitions

### DIFF
--- a/MetalGear/Game.cpp
+++ b/MetalGear/Game.cpp
@@ -34,6 +34,12 @@ bool Game::update(int deltaTime)
 			sceneInitialized = true;
 			// La música del mapa se iniciará en Scene::init()
 		}
+		else if (previousState != MenuState::PLAYING) {
+			// Si volvemos al juego desde el menú (sin reiniciar scene)
+			// restaurar la música del mapa actual
+			AudioManager::instance().updateMusicForMap(scene.getCurrentMapId());
+		}
+
 		scene.update(deltaTime);
 	}
 	else {
@@ -85,6 +91,8 @@ void Game::keyPressed(int key)
 
 		if (currentState == MenuState::PLAYING) {
 			menuScreen.setCurrentState(MenuState::MAIN_MENU);
+			// Reproducir música del menú al pausar
+			AudioManager::instance().playMusic("music_menu", true);
 		}
 		else {
 			bPlay = false;

--- a/MetalGear/Scene.h
+++ b/MetalGear/Scene.h
@@ -28,7 +28,8 @@ public:
     }
 
     bool isGameOver() const { return gameOver; }
-    int handleMouseClick(int mouseX, int mouseY); // Para manejar clics en game over - retorna 1=continue, 2=exit, 0=nada
+    int handleMouseClick(int mouseX, int mouseY);
+    int getCurrentMapId() const { return currentMapId; }
 
 private:
     void initShaders();


### PR DESCRIPTION
Added logic to resume map music when returning to the game from the menu and to play menu music when pausing the game. Exposed getCurrentMapId() in Scene to support music restoration.